### PR TITLE
Add traversaro as a mantainer

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,3 +48,4 @@ about:
 extra:
   recipe-maintainers:
     - seanyen
+    - traversaro


### PR DESCRIPTION
I know that the custom usage is to add yourself with you first contribution to the recipe, but in this case the recipe seems to be maintained just by @seanyen that I guess quite busy these days, so I thought it could make sense to add myself as this is a dependency of a ignition-common. cc @wolfv @Tobias-Fischer 