### PR TITLE
Cleanup use of VS2017 on Windows

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,7 +1,11 @@
+c_compiler:
+- vs2019
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- vs2019
 glib:
 - '2'
 target_platform:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,16 +15,15 @@ source:
   - path: CMakeLists.txt
 
 build:
-  number: 3
+  number: 4
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
 
 requirements:
   build:
     - gnuconfig  # [unix]
-    - {{ compiler('cxx') }}  # [not win]
-    - {{ compiler('c') }}    # [not win]
-    - vs2017_win-64          # [win]
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
     - cmake       # [win]
     - ninja       # [win]
     - make        # [not win]


### PR DESCRIPTION
conda-forge uses VS2019 by default, so there is no need to manully specify VS2017.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
